### PR TITLE
Add support for support.Fragment

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,10 +17,10 @@ getFragmentManager().beginTransaction()
                 .commit();
 ```
 
-A hosting `Activity` should implement `PinFragment.Listener` to perform actions when a PIN has been created or validated. 
+A hosting `Activity` should implement `PinListener` to perform actions when a PIN has been created or validated. 
 
 ```
-public interface Listener {
+public interface PinListener {
     public void onValidated();
     public void onPinCreated();
 }
@@ -79,6 +79,12 @@ PinFragmentConfiguration config =
 ```
 
 This configuration will instruct your `PinFragment` instance to run `onSave()` and `isValid()` in the background and post to your `PinFragment.Listener` only when a PIN has been successfully created or verified, meaning you don't need to think about scheduling things to happen in the background.
+
+Support Library v4 - Fragment
+=============================
+
+In order to allow use of Fragment from the support library v4, we've added a
+new class `PinSupportFragment` that behave exactly like `PinFragment` but use `android.support.v4.app.Fragment`. Make sure to use it if you need such behavior.
 
 Including in your project
 =========================

--- a/demo/build.gradle
+++ b/demo/build.gradle
@@ -21,6 +21,6 @@ android {
 
 dependencies {
     compile project(':library')
-    compile "com.android.support:support-v4:23.4.0"
-    compile "com.android.support:appcompat-v7:23.4.0"
+    compile 'com.android.support:support-v4:23.4.0'
+    compile 'com.android.support:appcompat-v7:23.4.0'
 }

--- a/demo/build.gradle
+++ b/demo/build.gradle
@@ -1,7 +1,7 @@
 apply plugin: 'com.android.application'
 
 android {
-    compileSdkVersion 21
+    compileSdkVersion 23
     buildToolsVersion "21.1.2"
 
     defaultConfig {
@@ -21,4 +21,6 @@ android {
 
 dependencies {
     compile project(':library')
+    compile "com.android.support:support-v4:23.4.0"
+    compile "com.android.support:appcompat-v7:23.4.0"
 }

--- a/demo/src/main/AndroidManifest.xml
+++ b/demo/src/main/AndroidManifest.xml
@@ -8,8 +8,17 @@
         android:label="@string/app_name"
         android:theme="@style/AppTheme" >
         <activity
-            android:name=".PinDemoActivity"
-            android:label="@string/app_name" >
+                android:name=".PinDemoActivity"
+                android:label="@string/app_name" >
+            <intent-filter>
+                <action android:name="android.intent.action.MAIN" />
+
+                <category android:name="android.intent.category.LAUNCHER" />
+            </intent-filter>
+        </activity>
+        <activity
+                android:name=".PinSupportDemoActivity"
+                android:label="@string/app_name" >
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />
 

--- a/demo/src/main/AndroidManifest.xml
+++ b/demo/src/main/AndroidManifest.xml
@@ -1,29 +1,28 @@
 <?xml version="1.0" encoding="utf-8"?>
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
-    package="com.venmo.android.pin.pindemo.demo" >
+          package="com.venmo.android.pin.pindemo.demo">
 
     <application
-        android:allowBackup="true"
-        android:icon="@drawable/ic_launcher"
-        android:label="@string/app_name"
-        android:theme="@style/AppTheme" >
+            android:allowBackup="true"
+            android:icon="@drawable/ic_launcher"
+            android:label="@string/app_name"
+            android:theme="@style/AppTheme">
         <activity
-                android:name=".PinDemoActivity"
-                android:label="@string/app_name" >
+                android:name=".PinLauncher"
+                android:label="@string/app_name">
             <intent-filter>
-                <action android:name="android.intent.action.MAIN" />
+                <action android:name="android.intent.action.MAIN"/>
 
-                <category android:name="android.intent.category.LAUNCHER" />
+                <category android:name="android.intent.category.LAUNCHER"/>
             </intent-filter>
         </activity>
         <activity
+                android:name=".PinDemoActivity"
+                android:label="@string/pin_sdk_fragment">
+        </activity>
+        <activity
                 android:name=".PinSupportDemoActivity"
-                android:label="@string/app_name" >
-            <intent-filter>
-                <action android:name="android.intent.action.MAIN" />
-
-                <category android:name="android.intent.category.LAUNCHER" />
-            </intent-filter>
+                android:label="@string/pin_support_fragment">
         </activity>
     </application>
 

--- a/demo/src/main/java/com/venmo/android/pin/pindemo/demo/PinDemoActivity.java
+++ b/demo/src/main/java/com/venmo/android/pin/pindemo/demo/PinDemoActivity.java
@@ -8,7 +8,7 @@ import android.view.MenuItem;
 import android.widget.Toast;
 
 import com.venmo.android.pin.PinListener;
-import com.venmo.android.pin.PinSdkFragment;
+import com.venmo.android.pin.PinFragment;
 import com.venmo.android.pin.util.PinHelper;
 
 public class PinDemoActivity extends Activity implements PinListener {
@@ -18,8 +18,8 @@ public class PinDemoActivity extends Activity implements PinListener {
         super.onCreate(savedInstanceState);
         setContentView(R.layout.activity_pin_demo);
         Fragment toShow = PinHelper.hasDefaultPinSaved(this) ?
-                PinSdkFragment.newInstanceForVerification() :
-                PinSdkFragment.newInstanceForCreation();
+                PinFragment.newInstanceForVerification() :
+                PinFragment.newInstanceForCreation();
 
         getFragmentManager().beginTransaction()
                 .replace(R.id.root, toShow, toShow.getClass().getSimpleName())

--- a/demo/src/main/java/com/venmo/android/pin/pindemo/demo/PinLauncher.java
+++ b/demo/src/main/java/com/venmo/android/pin/pindemo/demo/PinLauncher.java
@@ -1,0 +1,36 @@
+package com.venmo.android.pin.pindemo.demo;
+
+import android.content.Intent;
+import android.os.Bundle;
+import android.app.Activity;
+import android.view.View;
+
+public class PinLauncher extends Activity {
+
+    @Override
+    protected void onCreate(Bundle savedInstanceState) {
+        super.onCreate(savedInstanceState);
+        setContentView(R.layout.activity_pin_launcher);
+
+        final Intent launchIntent = new Intent();
+
+        findViewById(R.id.sdk_button).setOnClickListener(new View.OnClickListener() {
+            @Override
+            public void onClick(View v) {
+                launchIntent.setClass(PinLauncher.this, PinDemoActivity.class);
+
+                startActivity(launchIntent);
+            }
+        });
+
+        findViewById(R.id.support_button).setOnClickListener(new View.OnClickListener() {
+            @Override
+            public void onClick(View v) {
+                launchIntent.setClass(PinLauncher.this, PinSupportDemoActivity.class);
+
+                startActivity(launchIntent);
+            }
+        });
+    }
+
+}

--- a/demo/src/main/java/com/venmo/android/pin/pindemo/demo/PinSupportDemoActivity.java
+++ b/demo/src/main/java/com/venmo/android/pin/pindemo/demo/PinSupportDemoActivity.java
@@ -1,27 +1,27 @@
 package com.venmo.android.pin.pindemo.demo;
 
-import android.app.Activity;
-import android.app.Fragment;
 import android.os.Bundle;
+import android.support.v4.app.Fragment;
+import android.support.v4.app.FragmentActivity;
 import android.view.Menu;
 import android.view.MenuItem;
 import android.widget.Toast;
 
 import com.venmo.android.pin.PinListener;
-import com.venmo.android.pin.PinSdkFragment;
+import com.venmo.android.pin.PinSupportFragment;
 import com.venmo.android.pin.util.PinHelper;
 
-public class PinDemoActivity extends Activity implements PinListener {
+public class PinSupportDemoActivity extends FragmentActivity implements PinListener {
 
     @Override
     protected void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
         setContentView(R.layout.activity_pin_demo);
         Fragment toShow = PinHelper.hasDefaultPinSaved(this) ?
-                PinSdkFragment.newInstanceForVerification() :
-                PinSdkFragment.newInstanceForCreation();
+                PinSupportFragment.newInstanceForVerification() :
+                PinSupportFragment.newInstanceForCreation();
 
-        getFragmentManager().beginTransaction()
+        getSupportFragmentManager().beginTransaction()
                 .replace(R.id.root, toShow, toShow.getClass().getSimpleName())
                 .commit();
     }

--- a/demo/src/main/res/layout/activity_pin_demo.xml
+++ b/demo/src/main/res/layout/activity_pin_demo.xml
@@ -3,4 +3,4 @@
     android:id="@+id/root"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
-    tools:context=".PinDemoActivity" />
+    tools:context=".PinSupportDemoActivity" />

--- a/demo/src/main/res/layout/activity_pin_launcher.xml
+++ b/demo/src/main/res/layout/activity_pin_launcher.xml
@@ -1,0 +1,57 @@
+<?xml version="1.0" encoding="utf-8"?>
+<RelativeLayout
+        xmlns:android="http://schemas.android.com/apk/res/android"
+        xmlns:tools="http://schemas.android.com/tools"
+        xmlns:app="http://schemas.android.com/apk/res-auto"
+        android:id="@+id/activity_pin_launcher"
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
+        tools:context="com.venmo.android.pin.pindemo.demo.PinLauncher"
+        tools:layout_editor_absoluteX="0dp"
+        tools:layout_editor_absoluteY="73dp">
+
+    <TextView
+            android:text="Pin Demo"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            tools:layout_editor_absoluteX="127dp"
+            tools:layout_editor_absoluteY="106dp"
+            android:id="@+id/title"
+            android:textSize="30sp"
+            android:layout_marginLeft="16dp"
+            android:layout_marginStart="16dp"
+            tools:layout_constraintLeft_creator="0"
+            android:layout_marginRight="16dp"
+            android:layout_marginEnd="16dp"
+            tools:layout_constraintRight_creator="0"
+            android:layout_alignWithParentIfMissing="false"
+            android:layout_centerHorizontal="true"/>
+
+    <Button
+            android:text="SDK Demo"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            tools:layout_editor_absoluteX="56dp"
+            tools:layout_editor_absoluteY="149dp"
+            android:id="@+id/sdk_button"
+            android:layout_marginLeft="56dp"
+            android:layout_marginStart="56dp"
+            tools:layout_constraintLeft_creator="0"
+            android:layout_marginTop="8dp"
+            tools:layout_constraintTop_creator="0"
+            android:layout_below="@id/title"/>
+
+    <Button
+            android:text="Support Demo"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            tools:layout_editor_absoluteX="205dp"
+            tools:layout_editor_absoluteY="149dp"
+            android:id="@+id/support_button"
+            android:layout_marginRight="40dp"
+            android:layout_marginEnd="40dp"
+            tools:layout_constraintRight_creator="0"
+            tools:layout_constraintBaseline_creator="0"
+            android:layout_toRightOf="@id/sdk_button"
+            android:layout_alignBottom="@id/sdk_button"/>
+</RelativeLayout>

--- a/demo/src/main/res/menu/pin_demo.xml
+++ b/demo/src/main/res/menu/pin_demo.xml
@@ -1,6 +1,6 @@
 <menu xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:tools="http://schemas.android.com/tools"
-    tools:context=".PinDemoActivity" >
+    tools:context=".PinSupportDemoActivity" >
     <item android:id="@+id/action_settings"
         android:title="@string/action_reset_pin"
         android:orderInCategory="100"

--- a/demo/src/main/res/values/strings.xml
+++ b/demo/src/main/res/values/strings.xml
@@ -3,5 +3,7 @@
 
     <string name="app_name">PIN Demo</string>
     <string name="action_reset_pin">Reset PIN</string>
+    <string name="pin_sdk_fragment">PIN Sdk Demo</string>
+    <string name="pin_support_fragment">PIN Support Demo</string>
 
 </resources>

--- a/library/build.gradle
+++ b/library/build.gradle
@@ -3,7 +3,7 @@ import com.android.builder.core.BuilderConstants
 apply plugin: 'com.android.library'
 
 android {
-    compileSdkVersion 21
+    compileSdkVersion 23
     buildToolsVersion "21.1.2"
 
     defaultConfig {
@@ -30,6 +30,8 @@ android.libraryVariants.all { variant ->
 }
 
 dependencies {
+    compile "com.android.support:support-v4:23.4.0"
+    compile "com.android.support:appcompat-v7:23.4.0"
     androidTestCompile 'com.jayway.android.robotium:robotium-solo:5.2.1'
 }
 

--- a/library/src/androidTest/java/com/venmo/android/pin/PinFragmentTests.java
+++ b/library/src/androidTest/java/com/venmo/android/pin/PinFragmentTests.java
@@ -6,7 +6,6 @@ import android.test.ActivityInstrumentationTestCase2;
 
 import com.robotium.solo.Condition;
 import com.robotium.solo.Solo;
-import com.venmo.android.pin.PinFragment.PinDisplayType;
 import com.venmo.android.pin.util.PinHelper;
 import com.venmo.android.pin.view.PinKeyboardView;
 import com.venmo.android.pin.view.PinputView;

--- a/library/src/androidTest/java/com/venmo/android/pin/TestActivity.java
+++ b/library/src/androidTest/java/com/venmo/android/pin/TestActivity.java
@@ -31,12 +31,12 @@ public class TestActivity extends FragmentActivity implements PinListener {
                             reachedMaxTries.set(true);
                         }
                     });
-            PinSdkFragment pf = type == PinDisplayType.CREATE ?
-                    PinSdkFragment.newInstanceForCreation(config) :
-                    PinSdkFragment.newInstanceForVerification(config);
+            PinFragment pf = type == PinDisplayType.CREATE ?
+                    PinFragment.newInstanceForCreation(config) :
+                    PinFragment.newInstanceForVerification(config);
 
             getFragmentManager().beginTransaction()
-                    .add(R.id.container, pf, PinSdkFragment.class.getSimpleName())
+                    .add(R.id.container, pf, PinFragment.class.getSimpleName())
                     .commit();
         }
     }

--- a/library/src/androidTest/java/com/venmo/android/pin/TestSupportActivity.java
+++ b/library/src/androidTest/java/com/venmo/android/pin/TestSupportActivity.java
@@ -36,7 +36,7 @@ public class TestSupportActivity extends FragmentActivity implements PinListener
                     PinSupportFragment.newInstanceForVerification(config);
 
             getSupportFragmentManager().beginTransaction()
-                    .add(R.id.container, pf, PinSdkFragment.class.getSimpleName())
+                    .add(R.id.container, pf, PinFragment.class.getSimpleName())
                     .commit();
         }
     }

--- a/library/src/androidTest/java/com/venmo/android/pin/TestSupportActivity.java
+++ b/library/src/androidTest/java/com/venmo/android/pin/TestSupportActivity.java
@@ -9,7 +9,7 @@ import java.util.concurrent.atomic.AtomicBoolean;
 
 import static com.venmo.android.pin.PinFragmentConfiguration.UNLIMITED_TRIES;
 
-public class TestActivity extends FragmentActivity implements PinListener {
+public class TestSupportActivity extends FragmentActivity implements PinListener {
 
     static final String KEY_DISPLAY_TYPE = "com.venmo.test.pin_display_type";
     static final String KEY_MAX_TRIES = "com.venmo.test.pin_max_tries";
@@ -31,11 +31,11 @@ public class TestActivity extends FragmentActivity implements PinListener {
                             reachedMaxTries.set(true);
                         }
                     });
-            PinSdkFragment pf = type == PinDisplayType.CREATE ?
-                    PinSdkFragment.newInstanceForCreation(config) :
-                    PinSdkFragment.newInstanceForVerification(config);
+            PinSupportFragment pf = type == PinDisplayType.CREATE ?
+                    PinSupportFragment.newInstanceForCreation(config) :
+                    PinSupportFragment.newInstanceForVerification(config);
 
-            getFragmentManager().beginTransaction()
+            getSupportFragmentManager().beginTransaction()
                     .add(R.id.container, pf, PinSdkFragment.class.getSimpleName())
                     .commit();
         }

--- a/library/src/main/java/com/venmo/android/pin/AsyncValidator.java
+++ b/library/src/main/java/com/venmo/android/pin/AsyncValidator.java
@@ -2,7 +2,7 @@ package com.venmo.android.pin;
 
 /**
  * Marker interface to implement if a PIN validation should be run asynchronously (i.e. by making a
- * network request). {@link PinSdkFragment} will background the logic in your {@code AsyncValidator} if
+ * network request). {@link PinFragment} will background the logic in your {@code AsyncValidator} if
  * you implement it.
  */
 public interface AsyncValidator extends Validator {}

--- a/library/src/main/java/com/venmo/android/pin/AsyncValidator.java
+++ b/library/src/main/java/com/venmo/android/pin/AsyncValidator.java
@@ -2,7 +2,7 @@ package com.venmo.android.pin;
 
 /**
  * Marker interface to implement if a PIN validation should be run asynchronously (i.e. by making a
- * network request). {@link PinFragment} will background the logic in your {@code AsyncValidator} if
+ * network request). {@link PinSdkFragment} will background the logic in your {@code AsyncValidator} if
  * you implement it.
  */
 public interface AsyncValidator extends Validator {}

--- a/library/src/main/java/com/venmo/android/pin/BaseViewController.java
+++ b/library/src/main/java/com/venmo/android/pin/BaseViewController.java
@@ -26,7 +26,7 @@ import java.util.concurrent.ExecutorService;
 import static android.view.MotionEvent.ACTION_DOWN;
 import static java.util.concurrent.Executors.newSingleThreadExecutor;
 
-abstract class BaseViewController<T extends PinFragment> {
+abstract class BaseViewController<T extends PinFragmentImplement> {
 
     private ExecutorService mExecutor;
     protected T mPinFragment;

--- a/library/src/main/java/com/venmo/android/pin/BaseViewController.java
+++ b/library/src/main/java/com/venmo/android/pin/BaseViewController.java
@@ -26,10 +26,10 @@ import java.util.concurrent.ExecutorService;
 import static android.view.MotionEvent.ACTION_DOWN;
 import static java.util.concurrent.Executors.newSingleThreadExecutor;
 
-abstract class BaseViewController {
+abstract class BaseViewController<T extends PinFragment> {
 
     private ExecutorService mExecutor;
-    protected PinFragment mPinFragment;
+    protected T mPinFragment;
     protected Context mContext;
     protected PinputView mPinputView;
     protected PinKeyboardView mKeyboardView;
@@ -37,9 +37,9 @@ abstract class BaseViewController {
     protected ProgressBar mProgressBar;
     protected View mRootView;
 
-    /*package*/ BaseViewController(PinFragment f, View v) {
+    /*package*/ BaseViewController(T f, View v) {
         mPinFragment = f;
-        mContext = f.getActivity();
+        mContext = f.getContext();
         mRootView = v;
         init();
     }
@@ -152,7 +152,7 @@ abstract class BaseViewController {
         postToMain(new Runnable() {
             @Override
             public void run() {
-                Toast.makeText(mPinFragment.getActivity(), s, Toast.LENGTH_SHORT).show();
+                Toast.makeText(mContext, s, Toast.LENGTH_SHORT).show();
                 resetPinputView();
             }
         });

--- a/library/src/main/java/com/venmo/android/pin/ConfirmPinViewController.java
+++ b/library/src/main/java/com/venmo/android/pin/ConfirmPinViewController.java
@@ -6,10 +6,10 @@ import android.widget.Toast;
 import com.venmo.android.pin.view.PinputView;
 import com.venmo.android.pin.view.PinputView.OnCommitListener;
 
-class ConfirmPinViewController extends BaseViewController {
+class ConfirmPinViewController<T extends PinFragment> extends BaseViewController<T> {
     private String mTruthString;
 
-    ConfirmPinViewController(PinFragment f, View v, String truth) {
+    ConfirmPinViewController(T f, View v, String truth) {
         super(f, v);
         mTruthString = truth;
     }
@@ -71,7 +71,7 @@ class ConfirmPinViewController extends BaseViewController {
     }
 
     private void resetToCreate() {
-        mPinFragment.setDisplayType(PinFragment.PinDisplayType.CREATE);
+        mPinFragment.setDisplayType(PinDisplayType.CREATE);
         mPinFragment.setViewController(new CreatePinViewController(mPinFragment, mRootView));
     }
 

--- a/library/src/main/java/com/venmo/android/pin/ConfirmPinViewController.java
+++ b/library/src/main/java/com/venmo/android/pin/ConfirmPinViewController.java
@@ -6,7 +6,7 @@ import android.widget.Toast;
 import com.venmo.android.pin.view.PinputView;
 import com.venmo.android.pin.view.PinputView.OnCommitListener;
 
-class ConfirmPinViewController<T extends PinFragment> extends BaseViewController<T> {
+class ConfirmPinViewController<T extends PinFragmentImplement> extends BaseViewController<T> {
     private String mTruthString;
 
     ConfirmPinViewController(T f, View v, String truth) {

--- a/library/src/main/java/com/venmo/android/pin/CreatePinViewController.java
+++ b/library/src/main/java/com/venmo/android/pin/CreatePinViewController.java
@@ -6,8 +6,8 @@ import android.view.View;
 import com.venmo.android.pin.view.PinputView;
 import com.venmo.android.pin.view.PinputView.OnCommitListener;
 
-class CreatePinViewController extends BaseViewController {
-    CreatePinViewController(PinFragment f, View v) {
+class CreatePinViewController<T extends PinFragment> extends BaseViewController<T> {
+    CreatePinViewController(T f, View v) {
         super(f, v);
     }
 

--- a/library/src/main/java/com/venmo/android/pin/CreatePinViewController.java
+++ b/library/src/main/java/com/venmo/android/pin/CreatePinViewController.java
@@ -6,7 +6,7 @@ import android.view.View;
 import com.venmo.android.pin.view.PinputView;
 import com.venmo.android.pin.view.PinputView.OnCommitListener;
 
-class CreatePinViewController<T extends PinFragment> extends BaseViewController<T> {
+class CreatePinViewController<T extends PinFragmentImplement> extends BaseViewController<T> {
     CreatePinViewController(T f, View v) {
         super(f, v);
     }

--- a/library/src/main/java/com/venmo/android/pin/PinDisplayType.java
+++ b/library/src/main/java/com/venmo/android/pin/PinDisplayType.java
@@ -1,9 +1,5 @@
 package com.venmo.android.pin;
 
-/**
- * Created by rmercille on 6/13/16.
- */
-
 public enum PinDisplayType {
     VERIFY, CREATE, CONFIRM
 }

--- a/library/src/main/java/com/venmo/android/pin/PinDisplayType.java
+++ b/library/src/main/java/com/venmo/android/pin/PinDisplayType.java
@@ -1,0 +1,9 @@
+package com.venmo.android.pin;
+
+/**
+ * Created by rmercille on 6/13/16.
+ */
+
+public enum PinDisplayType {
+    VERIFY, CREATE, CONFIRM
+}

--- a/library/src/main/java/com/venmo/android/pin/PinFragment.java
+++ b/library/src/main/java/com/venmo/android/pin/PinFragment.java
@@ -9,7 +9,7 @@ import android.view.View;
 import android.view.ViewGroup;
 
 
-public class PinSdkFragment extends Fragment implements PinFragmentImplement {
+public class PinFragment extends Fragment implements PinFragmentImplement {
 
     private static final String KEY_FRAGMENT_VIEW_TYPE = "com.venmo.input_fragment_view_type";
 
@@ -19,24 +19,24 @@ public class PinSdkFragment extends Fragment implements PinFragmentImplement {
     private PinFragmentConfiguration mConfig;
     private View mRootView;
 
-    public static PinSdkFragment newInstanceForVerification() {
+    public static PinFragment newInstanceForVerification() {
         return newInstanceForVerification(null);
     }
 
-    public static PinSdkFragment newInstanceForVerification(PinFragmentConfiguration config) {
+    public static PinFragment newInstanceForVerification(PinFragmentConfiguration config) {
         return newInstance(PinDisplayType.VERIFY, config);
     }
 
-    public static PinSdkFragment newInstanceForCreation() {
+    public static PinFragment newInstanceForCreation() {
         return newInstanceForCreation(null);
     }
 
-    public static PinSdkFragment newInstanceForCreation(PinFragmentConfiguration config) {
+    public static PinFragment newInstanceForCreation(PinFragmentConfiguration config) {
         return newInstance(PinDisplayType.CREATE, config);
     }
 
-    private static PinSdkFragment newInstance(PinDisplayType type, PinFragmentConfiguration config) {
-        PinSdkFragment instance = new PinSdkFragment();
+    private static PinFragment newInstance(PinDisplayType type, PinFragmentConfiguration config) {
+        PinFragment instance = new PinFragment();
         Bundle bundle = new Bundle();
         bundle.putSerializable(KEY_FRAGMENT_VIEW_TYPE, type);
         instance.setArguments(bundle);

--- a/library/src/main/java/com/venmo/android/pin/PinFragment.java
+++ b/library/src/main/java/com/venmo/android/pin/PinFragment.java
@@ -1,130 +1,26 @@
 package com.venmo.android.pin;
 
-import android.app.Activity;
-import android.app.Fragment;
-import android.os.Bundle;
-import android.view.LayoutInflater;
-import android.view.View;
-import android.view.ViewGroup;
+import android.content.Context;
 
+/**
+ * Created by rmercille on 6/13/16.
+ */
+public interface PinFragment {
+    Context getContext();
 
-public class PinFragment extends Fragment {
+    String getString(int resId);
 
-    private static final String KEY_FRAGMENT_VIEW_TYPE = "com.venmo.input_fragment_view_type";
+    void setConfig(PinFragmentConfiguration config);
 
-    private Listener mListener;
-    private PinDisplayType mPinDisplayType;
-    private BaseViewController mViewController;
-    private PinFragmentConfiguration mConfig;
-    private View mRootView;
+    PinFragmentConfiguration getConfig();
 
-    public enum PinDisplayType {
-        VERIFY, CREATE, CONFIRM
-    }
+    void onPinCreationEntered(String pinEntry);
 
-    public interface Listener {
-        public void onValidated();
-        public void onPinCreated();
-    }
+    void setViewController(BaseViewController controller);
 
-    public static PinFragment newInstanceForVerification() {
-        return newInstanceForVerification(null);
-    }
+    void setDisplayType(PinDisplayType type);
 
-    public static PinFragment newInstanceForVerification(PinFragmentConfiguration config) {
-        return newInstance(PinDisplayType.VERIFY, config);
-    }
+    void notifyValid();
 
-    public static PinFragment newInstanceForCreation() {
-        return newInstanceForCreation(null);
-    }
-
-    public static PinFragment newInstanceForCreation(PinFragmentConfiguration config) {
-        return newInstance(PinDisplayType.CREATE, config);
-    }
-
-    private static PinFragment newInstance(PinDisplayType type, PinFragmentConfiguration config) {
-        PinFragment instance = new PinFragment();
-        Bundle bundle = new Bundle();
-        bundle.putSerializable(KEY_FRAGMENT_VIEW_TYPE, type);
-        instance.setArguments(bundle);
-        instance.setConfig(config);
-        return instance;
-    }
-
-    @Override
-    public void onCreate(Bundle savedInstanceState) {
-        super.onCreate(savedInstanceState);
-        setRetainInstance(true);
-        Bundle args = getArguments();
-        mPinDisplayType = (PinDisplayType) args.getSerializable(KEY_FRAGMENT_VIEW_TYPE);
-    }
-
-    @Override
-    public View onCreateView(LayoutInflater inflater, ViewGroup container,
-            Bundle savedInstanceState) {
-        mRootView = inflater.inflate(R.layout.layout_pin_view, container, false);
-        setDisplayType(mPinDisplayType);
-        initViewController();
-        return mRootView;
-    }
-
-    @Override
-    public void onAttach(Activity activity) {
-        super.onAttach(activity);
-        if (!(activity instanceof Listener)) {
-            throw new ClassCastException(
-                    "Hosting activity must implement PinFragment.Listener");
-        } else {
-            mListener = (Listener) activity;
-            if (mConfig == null) setConfig(new PinFragmentConfiguration(getActivity()));
-        }
-    }
-
-    public void setConfig(PinFragmentConfiguration config) {
-        mConfig = config;
-    }
-
-    public PinFragmentConfiguration getConfig() {
-        return mConfig;
-    }
-
-    void onPinCreationEntered(String pinEntry) {
-        mPinDisplayType = PinDisplayType.CONFIRM;
-        mViewController = new ConfirmPinViewController(this, mRootView, pinEntry);
-    }
-
-    void setViewController(BaseViewController controller) {
-        mViewController = controller;
-    }
-
-    void notifyValid() {
-        mListener.onValidated();
-    }
-
-    void notifyCreated() {
-        mListener.onPinCreated();
-    }
-
-    void setDisplayType(PinDisplayType type) {
-        mPinDisplayType = type;
-    }
-
-    private void initViewController() {
-        switch (mPinDisplayType) {
-            case VERIFY:
-                setViewController(new VerifyPinViewController(this, mRootView));
-                break;
-            case CREATE:
-                setViewController(new CreatePinViewController(this, mRootView));
-                break;
-            case CONFIRM:
-                mViewController.refresh(mRootView);
-                break;
-            default:
-                throw new IllegalStateException(
-                        "Invalid DisplayType " + mPinDisplayType.toString());
-        }
-    }
-
+    void notifyCreated();
 }

--- a/library/src/main/java/com/venmo/android/pin/PinFragmentImplement.java
+++ b/library/src/main/java/com/venmo/android/pin/PinFragmentImplement.java
@@ -5,7 +5,7 @@ import android.content.Context;
 /**
  * Created by rmercille on 6/13/16.
  */
-public interface PinFragment {
+public interface PinFragmentImplement {
     Context getContext();
 
     String getString(int resId);

--- a/library/src/main/java/com/venmo/android/pin/PinListener.java
+++ b/library/src/main/java/com/venmo/android/pin/PinListener.java
@@ -1,9 +1,5 @@
 package com.venmo.android.pin;
 
-/**
- * Created by rmercille on 6/13/16.
- */
-
 public interface PinListener {
     void onValidated();
     void onPinCreated();

--- a/library/src/main/java/com/venmo/android/pin/PinListener.java
+++ b/library/src/main/java/com/venmo/android/pin/PinListener.java
@@ -1,0 +1,11 @@
+package com.venmo.android.pin;
+
+/**
+ * Created by rmercille on 6/13/16.
+ */
+
+public interface PinListener {
+    void onValidated();
+    void onPinCreated();
+}
+

--- a/library/src/main/java/com/venmo/android/pin/PinSaver.java
+++ b/library/src/main/java/com/venmo/android/pin/PinSaver.java
@@ -1,5 +1,5 @@
 package com.venmo.android.pin;
 
 public interface PinSaver {
-    public void save(String pin);
+    void save(String pin);
 }

--- a/library/src/main/java/com/venmo/android/pin/PinSdkFragment.java
+++ b/library/src/main/java/com/venmo/android/pin/PinSdkFragment.java
@@ -9,7 +9,7 @@ import android.view.View;
 import android.view.ViewGroup;
 
 
-public class PinSdkFragment extends Fragment implements PinFragment {
+public class PinSdkFragment extends Fragment implements PinFragmentImplement {
 
     private static final String KEY_FRAGMENT_VIEW_TYPE = "com.venmo.input_fragment_view_type";
 

--- a/library/src/main/java/com/venmo/android/pin/PinSdkFragment.java
+++ b/library/src/main/java/com/venmo/android/pin/PinSdkFragment.java
@@ -1,0 +1,129 @@
+package com.venmo.android.pin;
+
+import android.app.Activity;
+import android.app.Fragment;
+import android.content.Context;
+import android.os.Bundle;
+import android.view.LayoutInflater;
+import android.view.View;
+import android.view.ViewGroup;
+
+
+public class PinSdkFragment extends Fragment implements PinFragment {
+
+    private static final String KEY_FRAGMENT_VIEW_TYPE = "com.venmo.input_fragment_view_type";
+
+    private PinListener mListener;
+    private PinDisplayType mPinDisplayType;
+    private BaseViewController mViewController;
+    private PinFragmentConfiguration mConfig;
+    private View mRootView;
+
+    public static PinSdkFragment newInstanceForVerification() {
+        return newInstanceForVerification(null);
+    }
+
+    public static PinSdkFragment newInstanceForVerification(PinFragmentConfiguration config) {
+        return newInstance(PinDisplayType.VERIFY, config);
+    }
+
+    public static PinSdkFragment newInstanceForCreation() {
+        return newInstanceForCreation(null);
+    }
+
+    public static PinSdkFragment newInstanceForCreation(PinFragmentConfiguration config) {
+        return newInstance(PinDisplayType.CREATE, config);
+    }
+
+    private static PinSdkFragment newInstance(PinDisplayType type, PinFragmentConfiguration config) {
+        PinSdkFragment instance = new PinSdkFragment();
+        Bundle bundle = new Bundle();
+        bundle.putSerializable(KEY_FRAGMENT_VIEW_TYPE, type);
+        instance.setArguments(bundle);
+        instance.setConfig(config);
+        return instance;
+    }
+
+    @Override
+    public void onCreate(Bundle savedInstanceState) {
+        super.onCreate(savedInstanceState);
+        setRetainInstance(true);
+        Bundle args = getArguments();
+        mPinDisplayType = (PinDisplayType) args.getSerializable(KEY_FRAGMENT_VIEW_TYPE);
+    }
+
+    @Override
+    public View onCreateView(LayoutInflater inflater, ViewGroup container,
+                             Bundle savedInstanceState) {
+        mRootView = inflater.inflate(R.layout.layout_pin_view, container, false);
+        setDisplayType(mPinDisplayType);
+        initViewController();
+        return mRootView;
+    }
+
+    @Override
+    public void onAttach(Activity activity) {
+        super.onAttach(activity);
+        if (!(activity instanceof PinListener)) {
+            throw new ClassCastException(
+                    "Hosting activity must implement PinFragment.Listener");
+        } else {
+            mListener = (PinListener) activity;
+            if (mConfig == null) setConfig(new PinFragmentConfiguration(getActivity()));
+        }
+    }
+
+    @Override
+    public Context getContext() {
+        return getActivity();
+    }
+
+    @Override
+    public void setConfig(PinFragmentConfiguration config) {
+        mConfig = config;
+    }
+
+    @Override
+    public PinFragmentConfiguration getConfig() {
+        return mConfig;
+    }
+
+    public void onPinCreationEntered(String pinEntry) {
+        mPinDisplayType = PinDisplayType.CONFIRM;
+        mViewController = new ConfirmPinViewController(this, mRootView, pinEntry);
+    }
+
+    public void setViewController(BaseViewController controller) {
+        mViewController = controller;
+    }
+
+    public void notifyValid() {
+        mListener.onValidated();
+    }
+
+    public void notifyCreated() {
+        mListener.onPinCreated();
+    }
+
+    public void setDisplayType(PinDisplayType type) {
+        mPinDisplayType = type;
+    }
+
+    private void initViewController() {
+        switch (mPinDisplayType) {
+            case VERIFY:
+                setViewController(new VerifyPinViewController(this, mRootView));
+                break;
+            case CREATE:
+                setViewController(new CreatePinViewController(this, mRootView));
+                break;
+            case CONFIRM:
+                mViewController.refresh(mRootView);
+                break;
+            default:
+                throw new IllegalStateException(
+                        "Invalid DisplayType " + mPinDisplayType.toString());
+        }
+    }
+
+}

--- a/library/src/main/java/com/venmo/android/pin/PinSupportFragment.java
+++ b/library/src/main/java/com/venmo/android/pin/PinSupportFragment.java
@@ -8,7 +8,7 @@ import android.view.View;
 import android.view.ViewGroup;
 
 
-public class PinSupportFragment extends Fragment implements PinFragment {
+public class PinSupportFragment extends Fragment implements PinFragmentImplement {
 
     private static final String KEY_FRAGMENT_VIEW_TYPE = "com.venmo.input_fragment_view_type";
 

--- a/library/src/main/java/com/venmo/android/pin/PinSupportFragment.java
+++ b/library/src/main/java/com/venmo/android/pin/PinSupportFragment.java
@@ -1,0 +1,121 @@
+package com.venmo.android.pin;
+
+import android.content.Context;
+import android.os.Bundle;
+import android.support.v4.app.Fragment;
+import android.view.LayoutInflater;
+import android.view.View;
+import android.view.ViewGroup;
+
+
+public class PinSupportFragment extends Fragment implements PinFragment {
+
+    private static final String KEY_FRAGMENT_VIEW_TYPE = "com.venmo.input_fragment_view_type";
+
+    private PinListener mListener;
+    private PinDisplayType mPinDisplayType;
+    private BaseViewController mViewController;
+    private PinFragmentConfiguration mConfig;
+    private View mRootView;
+
+    public static PinSupportFragment newInstanceForVerification() {
+        return newInstanceForVerification(null);
+    }
+
+    public static PinSupportFragment newInstanceForVerification(PinFragmentConfiguration config) {
+        return newInstance(PinDisplayType.VERIFY, config);
+    }
+
+    public static PinSupportFragment newInstanceForCreation() {
+        return newInstanceForCreation(null);
+    }
+
+    public static PinSupportFragment newInstanceForCreation(PinFragmentConfiguration config) {
+        return newInstance(PinDisplayType.CREATE, config);
+    }
+
+    private static PinSupportFragment newInstance(PinDisplayType type, PinFragmentConfiguration config) {
+        PinSupportFragment instance = new PinSupportFragment();
+        Bundle bundle = new Bundle();
+        bundle.putSerializable(KEY_FRAGMENT_VIEW_TYPE, type);
+        instance.setArguments(bundle);
+        instance.setConfig(config);
+        return instance;
+    }
+
+    @Override
+    public void onCreate(Bundle savedInstanceState) {
+        super.onCreate(savedInstanceState);
+        setRetainInstance(true);
+        Bundle args = getArguments();
+        mPinDisplayType = (PinDisplayType) args.getSerializable(KEY_FRAGMENT_VIEW_TYPE);
+    }
+
+    @Override
+    public View onCreateView(LayoutInflater inflater, ViewGroup container,
+                             Bundle savedInstanceState) {
+        mRootView = inflater.inflate(R.layout.layout_pin_view, container, false);
+        setDisplayType(mPinDisplayType);
+        initViewController();
+        return mRootView;
+    }
+
+    @Override
+    public void onAttach(Context context) {
+        super.onAttach(context);
+        if (!(context instanceof PinListener)) {
+            throw new ClassCastException(
+                    "Hosting activity must implement PinSupportFragment.Listener");
+        } else {
+            mListener = (PinListener) context;
+            if (mConfig == null) setConfig(new PinFragmentConfiguration(getActivity()));
+        }
+    }
+
+    public void setConfig(PinFragmentConfiguration config) {
+        mConfig = config;
+    }
+
+    public PinFragmentConfiguration getConfig() {
+        return mConfig;
+    }
+
+    public void onPinCreationEntered(String pinEntry) {
+        mPinDisplayType = PinDisplayType.CONFIRM;
+        mViewController = new ConfirmPinViewController(this, mRootView, pinEntry);
+    }
+
+    public void setViewController(BaseViewController controller) {
+        mViewController = controller;
+    }
+
+    public void notifyValid() {
+        mListener.onValidated();
+    }
+
+    public void notifyCreated() {
+        mListener.onPinCreated();
+    }
+
+    public void setDisplayType(PinDisplayType type) {
+        mPinDisplayType = type;
+    }
+
+    private void initViewController() {
+        switch (mPinDisplayType) {
+            case VERIFY:
+                setViewController(new VerifyPinViewController(this, mRootView));
+                break;
+            case CREATE:
+                setViewController(new CreatePinViewController(this, mRootView));
+                break;
+            case CONFIRM:
+                mViewController.refresh(mRootView);
+                break;
+            default:
+                throw new IllegalStateException(
+                        "Invalid DisplayType " + mPinDisplayType.toString());
+        }
+    }
+
+}

--- a/library/src/main/java/com/venmo/android/pin/TryDepletionListener.java
+++ b/library/src/main/java/com/venmo/android/pin/TryDepletionListener.java
@@ -1,5 +1,5 @@
 package com.venmo.android.pin;
 
 public interface TryDepletionListener {
-    public void onTriesDepleted();
+    void onTriesDepleted();
 }

--- a/library/src/main/java/com/venmo/android/pin/Validator.java
+++ b/library/src/main/java/com/venmo/android/pin/Validator.java
@@ -4,5 +4,5 @@ package com.venmo.android.pin;
  * Interface for clients to notify whether or not a String matches an expected output
  */
 public interface Validator {
-    public boolean isValid(String input);
+    boolean isValid(String input);
 }

--- a/library/src/main/java/com/venmo/android/pin/VerifyPinViewController.java
+++ b/library/src/main/java/com/venmo/android/pin/VerifyPinViewController.java
@@ -7,7 +7,7 @@ import com.venmo.android.pin.view.PinputView.OnCommitListener;
 
 import static android.preference.PreferenceManager.getDefaultSharedPreferences;
 
-class VerifyPinViewController<T extends PinFragment> extends BaseViewController<T> {
+class VerifyPinViewController<T extends PinFragmentImplement> extends BaseViewController<T> {
     private static final String KEY_INCORRECT_PIN_ATTEMPTS = "com.venmo.pin.incorrect_pin_attempts";
 
     VerifyPinViewController(T f, View v) {

--- a/library/src/main/java/com/venmo/android/pin/VerifyPinViewController.java
+++ b/library/src/main/java/com/venmo/android/pin/VerifyPinViewController.java
@@ -7,10 +7,10 @@ import com.venmo.android.pin.view.PinputView.OnCommitListener;
 
 import static android.preference.PreferenceManager.getDefaultSharedPreferences;
 
-class VerifyPinViewController extends BaseViewController {
+class VerifyPinViewController<T extends PinFragment> extends BaseViewController<T> {
     private static final String KEY_INCORRECT_PIN_ATTEMPTS = "com.venmo.pin.incorrect_pin_attempts";
 
-    VerifyPinViewController(PinFragment f, View v) {
+    VerifyPinViewController(T f, View v) {
         super(f, v);
     }
 


### PR DESCRIPTION
The change are needed in order to allow the use of Fragment from the support library. The code was change so that both Fragment would be supported. The main class previously called PinFragment has been rewritten in two flavor: **PinSdkFragment** original Android Fragment and **PinSupportFragment**, the support library version.

Also the demo app has been upgraded with the new classes